### PR TITLE
Fixed error on execution

### DIFF
--- a/export_saved.py
+++ b/export_saved.py
@@ -11,6 +11,8 @@ import argparse
 import csv
 import logging
 import sys
+reload(sys)
+sys.setdefaultencoding('utf-8')
 
 import praw
 


### PR DESCRIPTION
Got the following after waiting a few seconds. Made a change by adding two lines to the code as referenced here https://stackoverflow.com/questions/31137552/unicodeencodeerror-ascii-codec-cant-encode-character-at-special-name and now it works! Thanks so much for this.

Error details
$ python export_saved.py 
Traceback (most recent call last):
  File "export_saved.py", line 329, in <module>
    main()
  File "export_saved.py", line 323, in main
    save_saved(reddit)
  File "export_saved.py", line 287, in save_saved
    process(reddit, seq, "export-saved", "Reddit - Saved")
  File "export_saved.py", line 269, in process
    write_csv(csv_rows, file_name + ".csv")
  File "export_saved.py", line 246, in write_csv
    csvwriter.writerow(row)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xfc' in position 152: ordinal not in range(128)